### PR TITLE
feat: Add audio transcription config support

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -299,10 +299,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -552,10 +552,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   typed_data:
     dependency: transitive
     description:

--- a/lib/src/live_service.dart
+++ b/lib/src/live_service.dart
@@ -27,11 +27,19 @@ class LiveConnectParameters {
   final GenerationConfig? config;
   final Content? systemInstruction;
 
+  /// Enable transcription of user audio input
+  final AudioTranscriptionConfig? inputAudioTranscription;
+
+  /// Enable transcription of model audio output
+  final AudioTranscriptionConfig? outputAudioTranscription;
+
   LiveConnectParameters({
     required this.model,
     required this.callbacks,
     this.config,
     this.systemInstruction,
+    this.inputAudioTranscription,
+    this.outputAudioTranscription,
   });
 }
 
@@ -147,6 +155,8 @@ class LiveService {
           model: modelName,
           generationConfig: params.config,
           systemInstruction: params.systemInstruction,
+          inputAudioTranscription: params.inputAudioTranscription,
+          outputAudioTranscription: params.outputAudioTranscription,
         ),
       );
       session.sendMessage(setupMessage);

--- a/lib/src/model/models.dart
+++ b/lib/src/model/models.dart
@@ -95,11 +95,19 @@ class LiveClientSetup {
   final Content? systemInstruction;
   final List<Tool>? tools;
 
+  /// Enable transcription of user audio input
+  final AudioTranscriptionConfig? inputAudioTranscription;
+
+  /// Enable transcription of model audio output
+  final AudioTranscriptionConfig? outputAudioTranscription;
+
   LiveClientSetup({
     required this.model,
     this.generationConfig,
     this.systemInstruction,
     this.tools,
+    this.inputAudioTranscription,
+    this.outputAudioTranscription,
   });
 
   factory LiveClientSetup.fromJson(Map<String, dynamic> json) =>
@@ -179,7 +187,7 @@ class Transcription {
 @JsonSerializable(
   includeIfNull: false,
   createToJson: false,
-  // fieldRename: FieldRename.snake,
+  fieldRename: FieldRename.snake,
 )
 class LiveServerContent {
   final Content? modelTurn;
@@ -250,4 +258,16 @@ class Tool {
   factory Tool.fromJson(Map<String, dynamic> json) => _$ToolFromJson(json);
 
   Map<String, dynamic> toJson() => _$ToolToJson(this);
+}
+
+/// Configuration for audio transcription.
+/// When provided in the setup, enables transcription of audio input/output.
+@JsonSerializable(includeIfNull: false, fieldRename: FieldRename.snake)
+class AudioTranscriptionConfig {
+  AudioTranscriptionConfig();
+
+  factory AudioTranscriptionConfig.fromJson(Map<String, dynamic> json) =>
+      _$AudioTranscriptionConfigFromJson(json);
+
+  Map<String, dynamic> toJson() => _$AudioTranscriptionConfigToJson(this);
 }

--- a/lib/src/model/models.g.dart
+++ b/lib/src/model/models.g.dart
@@ -82,6 +82,16 @@ LiveClientSetup _$LiveClientSetupFromJson(Map<String, dynamic> json) =>
       tools: (json['tools'] as List<dynamic>?)
           ?.map((e) => Tool.fromJson(e as Map<String, dynamic>))
           .toList(),
+      inputAudioTranscription: json['input_audio_transcription'] == null
+          ? null
+          : AudioTranscriptionConfig.fromJson(
+              json['input_audio_transcription'] as Map<String, dynamic>,
+            ),
+      outputAudioTranscription: json['output_audio_transcription'] == null
+          ? null
+          : AudioTranscriptionConfig.fromJson(
+              json['output_audio_transcription'] as Map<String, dynamic>,
+            ),
     );
 
 Map<String, dynamic> _$LiveClientSetupToJson(LiveClientSetup instance) =>
@@ -90,6 +100,8 @@ Map<String, dynamic> _$LiveClientSetupToJson(LiveClientSetup instance) =>
       'generation_config': ?instance.generationConfig,
       'system_instruction': ?instance.systemInstruction,
       'tools': ?instance.tools,
+      'input_audio_transcription': ?instance.inputAudioTranscription,
+      'output_audio_transcription': ?instance.outputAudioTranscription,
     };
 
 LiveClientContent _$LiveClientContentFromJson(Map<String, dynamic> json) =>
@@ -157,21 +169,21 @@ Transcription _$TranscriptionFromJson(Map<String, dynamic> json) =>
 
 LiveServerContent _$LiveServerContentFromJson(Map<String, dynamic> json) =>
     LiveServerContent(
-      modelTurn: json['modelTurn'] == null
+      modelTurn: json['model_turn'] == null
           ? null
-          : Content.fromJson(json['modelTurn'] as Map<String, dynamic>),
-      turnComplete: json['turnComplete'] as bool?,
-      inputTranscription: json['inputTranscription'] == null
-          ? null
-          : Transcription.fromJson(
-              json['inputTranscription'] as Map<String, dynamic>,
-            ),
-      outputTranscription: json['outputTranscription'] == null
+          : Content.fromJson(json['model_turn'] as Map<String, dynamic>),
+      turnComplete: json['turn_complete'] as bool?,
+      inputTranscription: json['input_transcription'] == null
           ? null
           : Transcription.fromJson(
-              json['outputTranscription'] as Map<String, dynamic>,
+              json['input_transcription'] as Map<String, dynamic>,
             ),
-      generationComplete: json['generationComplete'] as bool?,
+      outputTranscription: json['output_transcription'] == null
+          ? null
+          : Transcription.fromJson(
+              json['output_transcription'] as Map<String, dynamic>,
+            ),
+      generationComplete: json['generation_complete'] as bool?,
     );
 
 LiveServerMessage _$LiveServerMessageFromJson(Map<String, dynamic> json) =>
@@ -203,3 +215,11 @@ UsageMetadata _$UsageMetadataFromJson(Map<String, dynamic> json) =>
 Tool _$ToolFromJson(Map<String, dynamic> json) => Tool();
 
 Map<String, dynamic> _$ToolToJson(Tool instance) => <String, dynamic>{};
+
+AudioTranscriptionConfig _$AudioTranscriptionConfigFromJson(
+  Map<String, dynamic> json,
+) => AudioTranscriptionConfig();
+
+Map<String, dynamic> _$AudioTranscriptionConfigToJson(
+  AudioTranscriptionConfig instance,
+) => <String, dynamic>{};


### PR DESCRIPTION
## Summary

This PR adds support for the input_audio_transcription and output_audio_transcription configuration options in the Gemini Live API setup.

## Changes

- Add AudioTranscriptionConfig class for transcription configuration
- Add inputAudioTranscription and outputAudioTranscription fields to LiveClientSetup
- Add corresponding fields to LiveConnectParameters
- Update LiveServerContent to properly parse input_transcription and output_transcription fields from API responses (using snake_case field rename)
- Regenerate JSON serialization code

## Usage

```dart
final session = await genAI.live.connect(
  LiveConnectParameters(
    model: 'gemini-2.5-flash-native-audio-preview-12-2025',
    config: GenerationConfig(responseModalities: [Modality.AUDIO]),
    inputAudioTranscription: AudioTranscriptionConfig(),
    outputAudioTranscription: AudioTranscriptionConfig(),
    callbacks: LiveCallbacks(
      onMessage: (message) {
        // Access transcriptions
        final inputText = message.serverContent?.inputTranscription?.text;
        final outputText = message.serverContent?.outputTranscription?.text;
      },
    ),
  ),
);
```

## Reference

- Gemini Live API Audio Transcription Documentation: https://ai.google.dev/api/multimodal-live#audio-transcription

## Note

The Gemini Live API transcription feature currently has a known bug where transcription data may not be returned even with correct configuration. This PR adds the client-side support so the feature will work once the API is fixed.