### PR TITLE
Catch connection errors and complete instead of timeout

### DIFF
--- a/lib/src/live_service.dart
+++ b/lib/src/live_service.dart
@@ -39,6 +39,9 @@ class LiveConnectError extends Error {
   final String message;
 
   LiveConnectError(this.message);
+
+  @override
+  String toString() => 'LiveConnectError: $message';
 }
 
 // Live API 서비스 클래스

--- a/lib/src/live_service.dart
+++ b/lib/src/live_service.dart
@@ -35,6 +35,12 @@ class LiveConnectParameters {
   });
 }
 
+class LiveConnectError extends Error {
+  final String message;
+
+  LiveConnectError(this.message);
+}
+
 // Live API 서비스 클래스
 class LiveService {
   final String apiKey;
@@ -125,6 +131,14 @@ class LiveService {
           params.callbacks.onError?.call(error, stackTrace);
         },
         onDone: () {
+          if (setupCompleter.isCompleted) {
+            setupCompleter.completeError(
+              LiveConnectError(
+                'Connection closed before setup completed. Code: ${channel.closeCode}, Reason: ${channel.closeReason}',
+              ),
+              StackTrace.current,
+            );
+          }
           params.callbacks.onClose?.call(
             channel.closeCode,
             channel.closeReason,


### PR DESCRIPTION
# Overview

Makes the client handle cases where the websocket closes before it opens. Currently the completer will timeout instead of fail when this happens.


## Steps to reproduce

Quite simple, connect with invalid parameters:

```dart
final session = await genAI.live.connect(
  LiveConnectParameters(
    model: 'invalid-model',
    callbacks: LiveCallbacks(
      onOpen: () {
        logInfo('✅ Gemini Live connection opened');
      },
    ),
  ),
);
```

This would previously raise a:
```
TimeoutException: WebSocket setup timed out after 10 seconds.
```

And now raises:
```
LiveConnectError: Connection closed before setup completed. Code: 1008, Reason: models/invalid-model is not found for API version v1beta, or is not supported for bidiGenerateContent. Call ListModels to s
```